### PR TITLE
Fix compilation

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       { version: "0.8.17" },
-      { version: "0.7.0" },
+      { version: "0.7.1" },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "@balancer-labs/v2-interfaces": "^0.4.0",
         "@balancer-labs/v2-solidity-utils": "^4.0.0",
-        "@nomicfoundation/hardhat-network-helpers": "^1.0.8"
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
+        "@openzeppelin/contracts": "^4.9.1"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
@@ -1319,6 +1320,11 @@
       "peerDependencies": {
         "hardhat": "^2.0.4"
       }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.1.tgz",
+      "integrity": "sha512-aLDTLu/If1qYIFW5g4ZibuQaUsFGWQPBq1mZKp/txaebUnGHDmmiBhRLY1tDNedN0m+fJtKZ1zAODS9Yk+V6uA=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -9274,6 +9280,11 @@
         "table": "^6.8.0",
         "undici": "^5.14.0"
       }
+    },
+    "@openzeppelin/contracts": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.1.tgz",
+      "integrity": "sha512-aLDTLu/If1qYIFW5g4ZibuQaUsFGWQPBq1mZKp/txaebUnGHDmmiBhRLY1tDNedN0m+fJtKZ1zAODS9Yk+V6uA=="
     },
     "@scure/base": {
       "version": "1.1.1",


### PR DESCRIPTION
Apparently `BalancerErrors` doesn't work with 0.7.0, so the pragma directive is slightly off.

This PR updates the compiler version to the one that we use in the balancer monorepo (see [here](https://github.com/balancer/balancer-v2-monorepo/blob/master/pvt/common/hardhat-base-config.ts#L44-L54)).